### PR TITLE
Add CLI get account statement

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/tendermint/tm-db v0.5.1
 	github.com/tidwall/gjson v1.3.2
 	github.com/tidwall/sjson v1.0.4
+	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e
 )
 
 // replace github.com/cosmos/cosmos-sdk => ./tmpvendor/cosmos-sdk

--- a/go.sum
+++ b/go.sum
@@ -541,6 +541,7 @@ golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e h1:vcxGaoTs7kV8m5Np9uUNQin4BrLOthgV7252N8V+FwY=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/x/queries/client/cli/query.go
+++ b/x/queries/client/cli/query.go
@@ -57,6 +57,9 @@ func GetQuerySpendableBalance(cdc *codec.Codec) *cobra.Command {
 			}
 
 			resp, _, err := cliCtx.Query(fmt.Sprintf("custom/%s/%s/%s", types.QuerierRoute, types.QuerySpendable, key))
+			if err != nil {
+				return err
+			}
 
 			var bal sdk.Coins
 			err = cdc.UnmarshalJSON(resp, &bal)

--- a/x/queries/client/cli/query.go
+++ b/x/queries/client/cli/query.go
@@ -6,14 +6,41 @@ package cli
 
 import (
 	"fmt"
+	"sort"
+	"sync"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/e-money/em-ledger/x/queries/types"
 
 	"github.com/cosmos/cosmos-sdk/client/context"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/codec"
+	"github.com/cosmos/cosmos-sdk/x/auth/client/utils"
 	"github.com/spf13/cobra"
+	"golang.org/x/sync/errgroup"
 )
+
+const (
+	defaultPage  = 1
+	defaultLimit = 30 // should be consistent with tendermint/tendermint/rpc/core/pipe.go:19
+
+	EventTypeTransfer     = "transfer"
+	AttributeKeyRecipient = "recipient"
+	sendTrx               = "Send"
+
+	// Add uniqueness to overlapping trx timestamps
+	trxHashPrefixLen = 6
+)
+
+type transferEvent struct {
+	from       string
+	to         string
+	coinAmount string
+	timestamp  string
+	trxHash    string
+}
+
+type txsRespMap map[string]sdk.TxResponse
 
 func GetQuerySpendableBalance(cdc *codec.Codec) *cobra.Command {
 	spendableBalanceCmd := &cobra.Command{
@@ -71,20 +98,120 @@ func GetQueryCirculatingSupplyCmd(cdc *codec.Codec) *cobra.Command {
 	return flags.GetCommands(circulatingSupplyCmd)[0]
 }
 
+// GetQueryStatementCmd displays debits and credit transactions of the given
+// account.
 func GetQueryStatementCmd(cdc *codec.Codec) *cobra.Command {
 	statementCmd := &cobra.Command{
 		Use:   "statement",
 		Short: "Display a statement for the given account",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			cliCtx := context.NewCLIContext().WithCodec(cdc)
 
-			// TODO
-			// Parse and verify argument address
-			// Use events query api to find transactions where the account is either "sender" or "recipient"
+			address, err := sdk.AccAddressFromBech32(args[0])
+			if err != nil {
+				return err
+			}
+
+			eventQueries := []string{
+				fmt.Sprintf("%s.%s='%s'", EventTypeTransfer, sdk.AttributeKeySender, address),
+				fmt.Sprintf("%s.%s='%s'", EventTypeTransfer, AttributeKeyRecipient, address),
+			}
+
+			txsTimestamps, addrTxs, err := postEventQueries(cliCtx, eventQueries)
+			if err != nil {
+				return err
+			}
+
+			// Display joined transactions
+			displayResults(txsTimestamps, addrTxs)
 
 			return nil
 		},
 	}
 
 	return flags.GetCommands(statementCmd)[0]
+}
+
+// postEventQueries concurrently multiple post requests one for each event
+// condition clause (till there is way to send a single combined query for
+// multiple event clauses returning additive ORed results) and joins the
+// results. Abandons processing in case of error immediately.
+func postEventQueries(cliCtx context.CLIContext, eventQueries []string) ([]string, txsRespMap, error) {
+	g := new(errgroup.Group)
+	var m sync.Mutex
+	addrTxs := make(txsRespMap)
+	// Sort merged transactions by timestamp
+	txsTimestamps := make([]string, 0)
+	for _, url := range eventQueries {
+		// Launch a goroutine to fetch the URL.
+		req := []string{url}
+		g.Go(func() error {
+			// Fetch the URL.
+			txsResult, err := utils.QueryTxsByEvents(cliCtx, req, defaultPage, defaultLimit)
+			if err != nil {
+				// do not return a partial statement
+				return err
+			}
+
+			m.Lock()
+			cacheTxs(txsResult, &txsTimestamps, addrTxs)
+			m.Unlock()
+
+			return nil
+		})
+	}
+
+	return txsTimestamps, addrTxs, g.Wait()
+}
+
+// sortTrxKey concatenates timestamp + a hash prefix to enable uniqueness
+func sortTrxKey(timestamp, hash string) string {
+	return timestamp + hash[:trxHashPrefixLen]
+}
+
+// cacheTxs in map and timestamps in slice for later sorting
+func cacheTxs(txsResult *sdk.SearchTxsResult, txsTimestamps *[]string, foundTxs txsRespMap) {
+	for _, trx := range txsResult.Txs {
+		key := sortTrxKey(trx.Timestamp, trx.TxHash)
+		foundTxs[key] = trx
+		*txsTimestamps = append(*txsTimestamps, key)
+	}
+}
+
+// displayResults of transactions on standard output by descending chronological order.
+func displayResults(txsTimestamps []string, addrTxs txsRespMap) {
+	sort.Strings(txsTimestamps)
+
+	// Present in descending order
+	for i := len(txsTimestamps) - 1; i >= 0; i-- {
+		trxKey := txsTimestamps[i]
+		trx := addrTxs[trxKey]
+		for _, log := range trx.Logs {
+			for _, ev := range log.Events {
+				if ev.Type != "transfer" {
+					continue
+				}
+				transferEvent := transferEvent{
+					timestamp: trxKey[:len(trxKey)-trxHashPrefixLen],
+					trxHash:   trx.TxHash,
+				}
+				for _, attr := range ev.Attributes {
+					switch attr.Key {
+					case AttributeKeyRecipient:
+						transferEvent.to = attr.Value
+					case sdk.AttributeKeySender:
+						transferEvent.from = attr.Value
+					case sdk.AttributeKeyAmount:
+						transferEvent.coinAmount = attr.Value
+					}
+				}
+				fmt.Printf("%s %s %10s to\n%s\nTransacted at %s\nTransaction# %s\n\n",
+					transferEvent.from, sendTrx, transferEvent.coinAmount,
+					transferEvent.to,
+					transferEvent.timestamp,
+					transferEvent.trxHash)
+			}
+		}
+	}
 }


### PR DESCRIPTION
Because of multiple requests (two), this approach is more complex than originally envisioned and temporary until a fix or workaround is employed for a composite events query.

Code sample:
Post concurrently and join transaction results.
Display in descending sorted order like in explorer.
