### PR TITLE
70 gh actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+on: [push, pull_request]
+name: QA
+jobs:
+  test:
+    strategy:
+      matrix:
+        go-version: [1.15.x, 1.16.x]
+        os: [ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.go-version }}
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Run Makefile Tests
+        run: make github-ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.15.x, 1.16.x]
+        go-version: [1.15.x]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/Makefile
+++ b/Makefile
@@ -84,6 +84,11 @@ test:
 bdd-test:
 	go test -mod=readonly -v -p 1 -timeout 1h --tags="bdd" bdd_test.go multisigauthority_test.go authority_test.go  market_test.go buyback_test.go capacity_test.go staking_test.go bep3swap_test.go
 
+github-ci: build-linux
+	$(MAKE) test
+	$(MAKE) clean
+	$(MAKE) bdd-test
+
 local-testnet:
 	go test -mod=readonly -v --tags="bdd" bdd_test.go localnet_test.go
 

--- a/Makefile
+++ b/Makefile
@@ -86,8 +86,7 @@ bdd-test:
 
 github-ci: build-linux
 	$(MAKE) test
-	$(MAKE) clean
-	$(MAKE) bdd-test
+	$(MAKE) proto-lint
 
 local-testnet:
 	go test -mod=readonly -v --tags="bdd" bdd_test.go localnet_test.go


### PR DESCRIPTION
Added build, test, proto linting

The bdd tests fail because of timeouts, it seems that actions run things a lot slower and all the sleep durations would have to be adjusted.