### PR TITLE
Remove the home-cooked version of validateDenom and replace with SDK …

### DIFF
--- a/util/denom_utils.go
+++ b/util/denom_utils.go
@@ -5,16 +5,10 @@
 package util
 
 import (
-	"fmt"
 	"strings"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
-
-func ValidateDenom(denom string) bool {
-	err := sdk.ValidateDenom(denom)
-	return err == nil
-}
 
 func ParseDenominations(denoms string) ([]string, error) {
 	res := make([]string, 0)
@@ -25,8 +19,8 @@ func ParseDenominations(denoms string) ([]string, error) {
 			continue
 		}
 
-		if !ValidateDenom(denom) {
-			return nil, fmt.Errorf("invalid denomination: %v", denom)
+		if err := sdk.ValidateDenom(denom); err != nil {
+			return nil, err
 		}
 
 		res = append(res, denom)

--- a/util/denom_utils_test.go
+++ b/util/denom_utils_test.go
@@ -9,13 +9,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestDenoms(t *testing.T) {
-	assert.True(t, ValidateDenom("eeur"))
-	// todo (reviewer): the regexp pattern for valid denoms was changed for IBC to `[a-zA-Z][a-zA-Z0-9/]{2,127}`
-	// assert.False(t, ValidateDenom("EEUR"))
-	assert.False(t, ValidateDenom("123456"))
-}
-
 func TestParseDenominations(t *testing.T) {
 	testdata := []struct {
 		denoms string

--- a/x/authority/keeper/keeper.go
+++ b/x/authority/keeper/keeper.go
@@ -9,7 +9,6 @@ import (
 	"sync"
 
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
-	"github.com/e-money/em-ledger/util"
 	"github.com/e-money/em-ledger/x/authority/types"
 	"github.com/e-money/em-ledger/x/issuer"
 
@@ -70,8 +69,8 @@ func (k Keeper) createIssuer(ctx sdk.Context, authority sdk.AccAddress, issuerAd
 	k.MustBeAuthority(ctx, authority)
 
 	for _, denom := range denoms {
-		if !util.ValidateDenom(denom) {
-			return nil, sdkerrors.Wrapf(types.ErrInvalidDenom, "Invalid denom: %v", denom)
+		if err := sdk.ValidateDenom(denom); err != nil {
+			return nil, sdkerrors.Wrapf(types.ErrInvalidDenom, err.Error())
 		}
 	}
 

--- a/x/issuer/client/cli/tx.go
+++ b/x/issuer/client/cli/tx.go
@@ -5,12 +5,10 @@
 package cli
 
 import (
-	"fmt"
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/client/tx"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/e-money/em-ledger/util"
 	"github.com/e-money/em-ledger/x/issuer/types"
 	"github.com/spf13/cobra"
 )
@@ -48,8 +46,8 @@ func getCmdSetInflation() *cobra.Command {
 			}
 
 			denom := args[1]
-			if !util.ValidateDenom(denom) {
-				return fmt.Errorf("invalid denomination: %v", denom)
+			if err := sdk.ValidateDenom(denom); err != nil {
+				return err
 			}
 
 			inflation, err := sdk.NewDecFromStr(args[2])

--- a/x/market/client/rest/query.go
+++ b/x/market/client/rest/query.go
@@ -9,7 +9,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/client"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/rest"
-	"github.com/e-money/em-ledger/util"
 	"github.com/e-money/em-ledger/x/market/types"
 	"github.com/gorilla/mux"
 	"net/http"
@@ -55,7 +54,7 @@ func queryInstrumentHandlerFn(cliCtx client.Context) http.HandlerFunc {
 		vars := mux.Vars(r)
 		src, dst := vars["src"], vars["dst"]
 
-		if !util.ValidateDenom(src) || !util.ValidateDenom(dst) {
+		if sdk.ValidateDenom(src) != nil || sdk.ValidateDenom(dst) != nil {
 			w.WriteHeader(http.StatusBadRequest)
 			return
 		}

--- a/x/market/keeper/grpc_query.go
+++ b/x/market/keeper/grpc_query.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
-	"github.com/e-money/em-ledger/util"
 	"github.com/e-money/em-ledger/x/market/types"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -42,7 +41,7 @@ func (k Keeper) Instrument(c context.Context, req *types.QueryInstrumentRequest)
 	ctx := sdk.UnwrapSDKContext(c)
 
 	source, destination := req.Source, req.Destination
-	if !util.ValidateDenom(source) || !util.ValidateDenom(destination) {
+	if sdk.ValidateDenom(source) != nil || sdk.ValidateDenom(destination) != nil {
 		return nil, sdkerrors.Wrapf(sdkerrors.ErrInvalidCoins, "Invalid denoms: %v %v", source, destination)
 	}
 

--- a/x/market/keeper/querier.go
+++ b/x/market/keeper/querier.go
@@ -7,7 +7,6 @@ package keeper
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/e-money/em-ledger/util"
 	"github.com/e-money/em-ledger/x/market/types"
 	"sort"
 
@@ -83,7 +82,7 @@ func queryInstrument(ctx sdk.Context, k *Keeper, path []string, req abci.Request
 
 	source, destination := path[0], path[1]
 
-	if !util.ValidateDenom(source) || !util.ValidateDenom(destination) {
+	if sdk.ValidateDenom(source) != nil || sdk.ValidateDenom(destination) != nil {
 		return nil, sdkerrors.Wrapf(sdkerrors.ErrInvalidCoins, "Invalid denoms: %v %v", source, destination)
 	}
 


### PR DESCRIPTION
`denom_utils.go` had a denomination-validating function that was made obsolete by the introduction of the `ValidateDenom` function in the SDK.

This PR migrates from the home-cooked version to the SDK version.