### PR TITLE
Fix for emcli.CustomCommand detecting trx failure

### DIFF
--- a/bep3swap_test.go
+++ b/bep3swap_test.go
@@ -10,9 +10,10 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
-	"github.com/e-money/em-ledger/networktest"
 	"strings"
 	"time"
+
+	"github.com/e-money/em-ledger/networktest"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -94,25 +95,19 @@ var _ = Describe("BEP3 Swap", func() {
 		)
 
 		It("Uses the wrong secret", func() {
-			var (
-				height int64
-				err    error
-			)
-			height, err = networktest.GetHeight()
-
 			randomNumber := make([]byte, 32)
-			_, err = rand.Read(randomNumber)
+			_, err := rand.Read(randomNumber)
 
 			Expect(err).ToNot(HaveOccurred())
 			wrongSecret := hex.EncodeToString(randomNumber)
 
-			height = incChainHeight(height)
+			networktest.IncChain(1)
 
 			output, err := emcli.BEP3Claim(
 				key1, swapId, wrongSecret,
 			)
-			Expect(err).ToNot(HaveOccurred())
-			height, err = networktest.GetHeight()
+			Expect(err).To(HaveOccurred())
+			networktest.IncChain(1)
 
 			jsonOutput := gjson.Parse(output)
 			Expect(jsonOutput.Get("codespace").Str).To(Equal("bep3"))
@@ -248,7 +243,7 @@ var _ = Describe("BEP3 Swap", func() {
 
 func incChainHeight(height int64) int64 {
 	// Will not exhaust it in most cases
-	var timeOutDur = 8 *time.Second
+	var timeOutDur = 8 * time.Second
 
 	newHeight, err := networktest.WaitForHeightWithTimeout(
 		height+1, timeOutDur,

--- a/market_test.go
+++ b/market_test.go
@@ -55,7 +55,7 @@ var _ = Describe("Market", func() {
 
 		It("Crashing validator can catch up", func() {
 			var (
-				err    error
+				err error
 			)
 			_, success, err := emcli.MarketAddLimitOrder(acc2, "5000eeur", "100000ejpy", "acc2cid1")
 			Expect(err).ToNot(HaveOccurred())
@@ -103,7 +103,7 @@ var _ = Describe("Market", func() {
 
 			aBlockHash, err := networktest.ChainBlockHash()
 			Expect(err).ToNot(HaveOccurred())
-			fmt.Printf("Looking for emdnode2 to participate in %s block commit\n",aBlockHash)
+			fmt.Printf("Looking for emdnode2 to participate in %s block commit\n", aBlockHash)
 
 			// +10 blocks to allow node2 to catch up
 			_, _ = networktest.IncChain(10)
@@ -184,7 +184,7 @@ var _ = Describe("Market", func() {
 			ioutil.WriteFile(transactionPath, txBz, 0777)
 
 			s, err = emcli.CustomCommand("tx", "broadcast", transactionPath)
-			Expect(err).To(BeNil())
+			Expect(err).NotTo(BeNil())
 			// Transaction must have failed due to insufficient gas
 			Expect(gjson.Parse(s).Get("logs.0.success").Exists()).To(Equal(false))
 
@@ -197,3 +197,4 @@ var _ = Describe("Market", func() {
 		})
 	})
 })
+

--- a/multisigauthority_test.go
+++ b/multisigauthority_test.go
@@ -72,7 +72,7 @@ var _ = Describe("Authority", func() {
 			ioutil.WriteFile(transactionPath, []byte(tx), 0777)
 
 			tx, err = emcli.CustomCommand("tx", "broadcast", transactionPath)
-			Expect(err).To(BeNil())
+			Expect(err).NotTo(BeNil())
 			Expect(gjson.Parse(tx).Get("logs.0.success").Exists()).To(Equal(false))
 		})
 

--- a/networktest/emcli.go
+++ b/networktest/emcli.go
@@ -57,14 +57,22 @@ func (cli Emcli) AuthorityDestroyIssuer(authority, issuer Key) (string, bool, er
 }
 
 func (cli Emcli) CustomCommand(params ...string) (string, error) {
+	// any non-broadcasting should not check the hash, code, logs result
+	re := regexp.MustCompile(`generate-only|sign`)
+	checkTxRes := true
+	for _, param := range params {
+		if re.MatchString(param) {
+			checkTxRes = false
+		}
+	}
 	args := cli.addTransactionFlags(params...)
-	return execCmdCollectOutput(args, KeyPwd)
+	return execCmdCollectOutput(args, KeyPwd, checkTxRes)
 }
 
 func (cli Emcli) AuthoritySetMinGasPricesMulti(from, minGasPrices string, params ...string) (string, error) {
 	args := cli.addTransactionFlags("tx", "authority", "set-gas-prices", from, minGasPrices)
 	args = append(args, params...)
-	return execCmdCollectOutput(args, KeyPwd)
+	return execCmdCollectOutput(args, KeyPwd, true)
 }
 
 func (cli Emcli) AuthoritySetMinGasPrices(authority Key, minGasPrices string, params ...string) (string, bool, error) {
@@ -235,7 +243,7 @@ func (cli Emcli) QueryDelegations(account string) ([]byte, error) {
 
 func (cli Emcli) SignTranscation(txPath, fromAddress, multisigAddress string) (string, error) {
 	args := cli.addTransactionFlags("tx", "sign", txPath, "--from", fromAddress, "--multisig", multisigAddress)
-	return execCmdCollectOutput(args, KeyPwd)
+	return execCmdCollectOutput(args, KeyPwd, false)
 }
 
 func (cli Emcli) IssuerIncreaseMintableAmount(issuer, liquidityprovider Key, amount string) (string, bool, error) {
@@ -292,7 +300,7 @@ func (cli Emcli) UnjailValidator(key string) (string, bool, error) {
 
 func (cli Emcli) BEP3Create(creator Key, recipient, otherChainRecipient, otherChainSender, coins string, TTL int) (string, string, string, error) {
 	args := cli.addTransactionFlags("tx", "bep3", "create", recipient, otherChainRecipient, otherChainSender, "now", coins, fmt.Sprint(TTL), "--from", creator.name)
-	output, err := execCmdCollectOutput(args, KeyPwd)
+	output, err := execCmdCollectOutput(args, KeyPwd, true)
 	if err != nil {
 		return "", "", "", err
 	}
@@ -312,7 +320,7 @@ func (cli Emcli) BEP3Create(creator Key, recipient, otherChainRecipient, otherCh
 func (cli Emcli) BEP3Claim(claimant Key, swapId, secret string) (string, error) {
 	args := cli.addTransactionFlags("tx", "bep3", "claim", swapId, secret, "--from", claimant.name)
 
-	return execCmdCollectOutput(args, KeyPwd)
+	return execCmdCollectOutput(args, KeyPwd, true)
 }
 
 func extractTxHash(bz []byte) (txhash string, success bool, err error) {
@@ -335,7 +343,7 @@ func extractTxHash(bz []byte) (txhash string, success bool, err error) {
 	return txhashjson.Str, true, nil
 }
 
-func execCmdCollectOutput(arguments []string, input string) (string, error) {
+func execCmdCollectOutput(arguments []string, input string, checkTxRes bool) (string, error) {
 	cmd := exec.Command(EMCLI, arguments...)
 
 	stdin, err := cmd.StdinPipe()
@@ -358,12 +366,17 @@ func execCmdCollectOutput(arguments []string, input string) (string, error) {
 		return "", err
 	}
 
-	_, ok, err := extractTxHash(bz)
-	if err != nil {
-		return "", err
-	}
-	if !ok {
-		return "", errors.New("transaction failed")
+	// --generate-only trx do not submit
+	if checkTxRes {
+		jsonStIndex := strings.IndexByte(string(bz), '{')
+
+		_, ok, err := extractTxHash(bz[jsonStIndex:])
+		if err != nil {
+			return string(bz), err
+		}
+		if !ok {
+			return "", errors.New("transaction failed")
+		}
 	}
 
 	return string(bz), nil


### PR DESCRIPTION
This is a tiny fix surfacing two greater issues:

1. Short-term: Similar to this, consolidate different ways of processing Cli output i.e. ```execCmdCollectOutput```, ```execCmdWithInput``` Or document their distinct purpose.
2. Longer-term: Replace the CLI outer shell process execution with a Protocol API approach that consumes the transaction API results directly i.e., gRPC, Docker API surfaces.

