### PR TITLE
#139 Add lilmermaid-16 denom-metadata to local-testnet

### DIFF
--- a/networktest/denom_metadata.go
+++ b/networktest/denom_metadata.go
@@ -1,0 +1,83 @@
+package networktest
+
+// local testnet genesis denomination meta-data
+// copied from https://github.com/e-money/networks/blob/master/lilmermaid-16/genesis.json
+var denomMetadata = `[
+		{
+          "base": "ungm",
+          "denom_units": [
+            {
+              "aliases": [],
+              "denom": "ungm",
+              "exponent": 0
+            },
+            {
+              "aliases": [],
+              "denom": "ngm",
+              "exponent": 6
+            }
+          ],
+          "description": "e-Money NGM staking token",
+          "display": "NGM"
+        },
+        {
+          "base": "echf",
+          "denom_units": [
+            {
+              "aliases": [],
+              "denom": "echf",
+              "exponent": 6
+            }
+          ],
+          "description": "e-Money CHF stablecoin",
+          "display": "ECHF"
+        },
+        {
+          "base": "edkk",
+          "denom_units": [
+            {
+              "aliases": [],
+              "denom": "edkk",
+              "exponent": 6
+            }
+          ],
+          "description": "e-Money DKK stablecoin",
+          "display": "EDKK"
+        },
+        {
+          "base": "eeur",
+          "denom_units": [
+            {
+              "aliases": [],
+              "denom": "eeur",
+              "exponent": 6
+            }
+          ],
+          "description": "e-Money EUR stablecoin",
+          "display": "EEUR"
+        },
+        {
+          "base": "enok",
+          "denom_units": [
+            {
+              "aliases": [],
+              "denom": "enok",
+              "exponent": 6
+            }
+          ],
+          "description": "e-Money NOK stablecoin",
+          "display": "ENOK"
+        },
+        {
+          "base": "esek",
+          "denom_units": [
+            {
+              "aliases": [],
+              "denom": "esek",
+              "exponent": 6
+            }
+          ],
+          "description": "e-Money SEK stablecoin",
+          "display": "ESEK"
+        }
+    ]`

--- a/networktest/testnet.go
+++ b/networktest/testnet.go
@@ -263,6 +263,8 @@ func (t *Testnet) updateGenesis() {
 	genesisTime := time.Now().Add(10 * time.Second).UTC().Format(time.RFC3339)
 	bz, _ = sjson.SetBytes(bz, "genesis_time", genesisTime)
 
+	bz, _ = sjson.SetRawBytes(bz, "app_state.bank.denom_metadata", []byte(denomMetadata))
+
 	t.genesis = bz
 
 	writeGenesisFiles(bz)


### PR DESCRIPTION
Draft PR. If we defer additional work on this issue, let's add the metadata to our local testnet.

test
```shell
make local-testnet
build/emd q bank denom-metadata --node tcp://localhost:26657 | jq
```
```json
{
  "metadatas": [
    {
      "description": "e-Money CHF stablecoin",
      "denom_units": [
        {
          "denom": "echf",
          "exponent": 6,
          "aliases": []
        }
      ],
      "base": "echf",
      "display": "ECHF"
    },
...
```
